### PR TITLE
Fix minor spelling issues in test sites

### DIFF
--- a/Source/TestSites/AspNetCore_net462_TestApp/Startup.cs
+++ b/Source/TestSites/AspNetCore_net462_TestApp/Startup.cs
@@ -44,7 +44,7 @@ namespace AspNetCore_Net462_TestApp
             // In this case we just return the same configuration for everyone.
             app.UseTus(httpContext => Task.FromResult(httpContext.RequestServices.GetService<DefaultTusConfiguration>()));
 
-            // All GET requests to tusdotnet are forwared so that you can handle file downloads.
+            // All GET requests to tusdotnet are forwarded so that you can handle file downloads.
             // This is done because the file's metadata is domain specific and thus cannot be handled 
             // in a generic way by tusdotnet.
             app.UseSimpleDownloadMiddleware(httpContext => Task.FromResult(httpContext.RequestServices.GetService<DefaultTusConfiguration>()));

--- a/Source/TestSites/AspNetCore_net462_TestApp/wwwroot/index.html
+++ b/Source/TestSites/AspNetCore_net462_TestApp/wwwroot/index.html
@@ -48,7 +48,7 @@
         <br /><br />
         <a href="https://developers.google.com/web/tools/chrome-devtools/network-performance/network-conditions" target="_blank">Throttle your network</a> to make it easier to follow the requests and responses.
         <br /><br />
-        <a href="#" onclick="resetLocalCache(event)" title="Once an upload has started the file url is cached in browse. Click here to reset this cache so that all files will be uploaded from scratch.">Reset local file cache to restart uploads from scratch</a>
+        <a href="#" onclick="resetLocalCache(event)" title="Once an upload has started the file url is cached in browser. Click here to reset this cache so that all files will be uploaded from scratch.">Reset local file cache to restart uploads from scratch</a>
 
         <div class="uploadControl">
             <input type="file" name="droppedFile" id="droppedFile" />

--- a/Source/TestSites/AspNetCore_netcoreapp1.1_TestApp/Startup.cs
+++ b/Source/TestSites/AspNetCore_netcoreapp1.1_TestApp/Startup.cs
@@ -46,7 +46,7 @@ namespace AspNetCore_netcoreapp1_1_TestApp
             // In this case we just return the same configuration for everyone.
             app.UseTus(httpContext => Task.FromResult(httpContext.RequestServices.GetService<DefaultTusConfiguration>()));
 
-            // All GET requests to tusdotnet are forwared so that you can handle file downloads.
+            // All GET requests to tusdotnet are forwarded so that you can handle file downloads.
             // This is done because the file's metadata is domain specific and thus cannot be handled 
             // in a generic way by tusdotnet.
             app.UseSimpleDownloadMiddleware(httpContext => Task.FromResult(httpContext.RequestServices.GetService<DefaultTusConfiguration>()));

--- a/Source/TestSites/AspNetCore_netcoreapp1.1_TestApp/wwwroot/index.html
+++ b/Source/TestSites/AspNetCore_netcoreapp1.1_TestApp/wwwroot/index.html
@@ -48,7 +48,7 @@
         <br /><br />
         <a href="https://developers.google.com/web/tools/chrome-devtools/network-performance/network-conditions" target="_blank">Throttle your network</a> to make it easier to follow the requests and responses.
         <br /><br />
-        <a href="#" onclick="resetLocalCache(event)" title="Once an upload has started the file url is cached in browse. Click here to reset this cache so that all files will be uploaded from scratch.">Reset local file cache to restart uploads from scratch</a>
+        <a href="#" onclick="resetLocalCache(event)" title="Once an upload has started the file url is cached in browser. Click here to reset this cache so that all files will be uploaded from scratch.">Reset local file cache to restart uploads from scratch</a>
 
         <div class="uploadControl">
             <input type="file" name="droppedFile" id="droppedFile" />

--- a/Source/TestSites/AspNetCore_netcoreapp2.1_TestApp/Startup.cs
+++ b/Source/TestSites/AspNetCore_netcoreapp2.1_TestApp/Startup.cs
@@ -44,7 +44,7 @@ namespace AspNetCore_netcoreapp2_1_TestApp
             // In this case we just return the same configuration for everyone.
             app.UseTus(httpContext => Task.FromResult(httpContext.RequestServices.GetService<DefaultTusConfiguration>()));
 
-            // All GET requests to tusdotnet are forwared so that you can handle file downloads.
+            // All GET requests to tusdotnet are forwarded so that you can handle file downloads.
             // This is done because the file's metadata is domain specific and thus cannot be handled 
             // in a generic way by tusdotnet.
             app.UseSimpleDownloadMiddleware(httpContext => Task.FromResult(httpContext.RequestServices.GetService<DefaultTusConfiguration>()));

--- a/Source/TestSites/AspNetCore_netcoreapp2.1_TestApp/wwwroot/index.html
+++ b/Source/TestSites/AspNetCore_netcoreapp2.1_TestApp/wwwroot/index.html
@@ -48,7 +48,7 @@
         <br /><br />
         <a href="https://developers.google.com/web/tools/chrome-devtools/network-performance/network-conditions" target="_blank">Throttle your network</a> to make it easier to follow the requests and responses.
         <br /><br />
-        <a href="#" onclick="resetLocalCache(event)" title="Once an upload has started the file url is cached in browse. Click here to reset this cache so that all files will be uploaded from scratch.">Reset local file cache to restart uploads from scratch</a>
+        <a href="#" onclick="resetLocalCache(event)" title="Once an upload has started the file url is cached in browser. Click here to reset this cache so that all files will be uploaded from scratch.">Reset local file cache to restart uploads from scratch</a>
 
         <div class="uploadControl">
             <input type="file" name="droppedFile" id="droppedFile" />

--- a/Source/TestSites/Owin_net452_TestApp/Startup.cs
+++ b/Source/TestSites/Owin_net452_TestApp/Startup.cs
@@ -34,7 +34,7 @@ namespace OwinTestApp
             // In this case we just return the same configuration for everyone.
             app.UseTus(owinRequest => tusConfiguration);
 
-            // All GET requests to tusdotnet are forwared so that you can handle file downloads.
+            // All GET requests to tusdotnet are forwarded so that you can handle file downloads.
             // This is done because the file's metadata is domain specific and thus cannot be handled 
             // in a generic way by tusdotnet.
             SetupDownloadFeature(app, tusConfiguration);

--- a/Source/TestSites/Owin_net452_TestApp/index.html
+++ b/Source/TestSites/Owin_net452_TestApp/index.html
@@ -48,7 +48,7 @@
         <br /><br />
         <a href="https://developers.google.com/web/tools/chrome-devtools/network-performance/network-conditions" target="_blank">Throttle your network</a> to make it easier to follow the requests and responses.
         <br /><br />
-        <a href="#" onclick="resetLocalCache(event)" title="Once an upload has started the file url is cached in browse. Click here to reset this cache so that all files will be uploaded from scratch.">Reset local file cache to restart uploads from scratch</a>
+        <a href="#" onclick="resetLocalCache(event)" title="Once an upload has started the file url is cached in browser. Click here to reset this cache so that all files will be uploaded from scratch.">Reset local file cache to restart uploads from scratch</a>
 
         <div class="uploadControl">
             <input type="file" name="droppedFile" id="droppedFile" />


### PR DESCRIPTION
While playing with the site examples, I noticed a few very minor typos. 