### PR TITLE
Performance improvement when uploading big files (100gb++)

### DIFF
--- a/Source/tusdotnet.test/Tests/TusDiskStoreTests.cs
+++ b/Source/tusdotnet.test/Tests/TusDiskStoreTests.cs
@@ -269,6 +269,24 @@ namespace tusdotnet.test.Tests
         }
 
         [Fact]
+        public async Task VerifyCorrectDataWrittenToDisk()
+        {
+            var random = new Random();
+            const int bufferSize = 5321;
+            var fakeData = new Byte[bufferSize];
+            for (int i = 0; i < bufferSize; i++)
+                fakeData[i] = (byte)random.Next(0, 255);
+
+
+            var fileId = await _fixture.Store.CreateFileAsync(fakeData.Length, null, CancellationToken.None);
+            using (var stream = new MemoryStream(fakeData))
+            {
+                var dataWrittenToDisk = await _fixture.Store.AppendDataAsync(fileId, stream, CancellationToken.None);
+                dataWrittenToDisk.ShouldBe(bufferSize);
+            }            
+        }
+
+        [Fact]
         public async Task VerifyChecksumAsync()
         {
             const string checksum = "9jSJuBxGMnq4UffwNYM8ct1tYQQ=";

--- a/Source/tusdotnet/Stores/TusDiskStore.cs
+++ b/Source/tusdotnet/Stores/TusDiskStore.cs
@@ -39,7 +39,7 @@ namespace tusdotnet.Stores
         /// Using this overload will not delete partial files if a final concatenation is performed.
         /// </summary>
         /// <param name="directoryPath">The path on disk where to save files</param>
-        public TusDiskStore(string directoryPath) : this(directoryPath, false)
+        public TusDiskStore(string directoryPath) : this(directoryPath, false, 51200)
         {
             // Left blank.
         }
@@ -49,7 +49,18 @@ namespace tusdotnet.Stores
         /// </summary>
         /// <param name="directoryPath">The path on disk where to save files</param>
         /// <param name="deletePartialFilesOnConcat">True to delete partial files if a final concatenation is performed</param>
-        public TusDiskStore(string directoryPath, bool deletePartialFilesOnConcat, int byteChunkSize = 5120000)
+        public TusDiskStore(string directoryPath, bool deletePartialFilesOnConcat) : this(directoryPath, false, 51200)
+        {
+            
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TusDiskStore"/> class.
+        /// </summary>
+        /// <param name="directoryPath">The path on disk where to save files</param>
+        /// <param name="deletePartialFilesOnConcat">True to delete partial files if a final concatenation is performed</param>
+        /// <param name="byteChunkSize">This allows you to set the chunk size, same as your clients. Higher values lowers Disk/CPU at the cost of RAM</param>
+        public TusDiskStore(string directoryPath, bool deletePartialFilesOnConcat, int byteChunkSize)
         {
             _directoryPath = directoryPath;
             _deletePartialFilesOnConcat = deletePartialFilesOnConcat;
@@ -96,7 +107,6 @@ namespace tusdotnet.Stores
                     }
 
                     bytesRead = await stream.ReadAsync(buffer, 0, _byteChunkSize, cancellationToken);
-
                     fileLength += bytesRead;
 
                     if (fileLength > uploadLength)

--- a/Source/tusdotnet/Stores/TusDiskStore.cs
+++ b/Source/tusdotnet/Stores/TusDiskStore.cs
@@ -32,7 +32,7 @@ namespace tusdotnet.Stores
         // Number of bytes to read at the time from the input stream.
         // The lower the value, the less data needs to be re-submitted on errors.
         // However, the lower the value, the slower the operation is. 51200 = 50 KB.
-        private readonly int ByteChunkSize;
+        private readonly int _byteChunkSize;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TusDiskStore"/> class.
@@ -54,15 +54,15 @@ namespace tusdotnet.Stores
             _directoryPath = directoryPath;
             _deletePartialFilesOnConcat = deletePartialFilesOnConcat;
             _fileRepFactory = new InternalFileRep.FileRepFactory(_directoryPath);
-            ByteChunkSize = byteChunkSize;
+            _byteChunkSize = byteChunkSize;
         }
 
         /// <inheritdoc />
         public async Task<long> AppendDataAsync(string fileId, Stream stream, CancellationToken cancellationToken)
         {
             var internalFileId = new InternalFileId(fileId);
-            var buffer = new byte[ByteChunkSize];
-            var chunkBuffer = new MemoryStream(ByteChunkSize);
+            var buffer = new byte[_byteChunkSize];
+            var chunkBuffer = new MemoryStream(_byteChunkSize);
             long bytesWritten = 0;
             var uploadLength = await GetUploadLengthAsync(fileId, cancellationToken);
             using (var file = _fileRepFactory.Data(internalFileId).GetStream(FileMode.Append, FileAccess.Write, FileShare.None))
@@ -95,7 +95,7 @@ namespace tusdotnet.Stores
                         break;
                     }
 
-                    bytesRead = await stream.ReadAsync(buffer, 0, ByteChunkSize, cancellationToken);
+                    bytesRead = await stream.ReadAsync(buffer, 0, _byteChunkSize, cancellationToken);
 
                     fileLength += bytesRead;
 

--- a/Source/tusdotnet/Stores/TusDiskStore.cs
+++ b/Source/tusdotnet/Stores/TusDiskStore.cs
@@ -110,7 +110,8 @@ namespace tusdotnet.Stores
 
                 } while (bytesRead != 0);
                 
-                file.Write(chunkBuffer.ToArray(), 0, (int)bytesWritten);
+                if(bytesWritten != 0) // Flush the full chunk to disk.
+                    file.Write(chunkBuffer.ToArray(), 0, (int)bytesWritten);
 
                 // Chunk is complete. Mark it as complete.
                 chunkComplete.Write("1");

--- a/Source/tusdotnet/Stores/TusDiskStore.cs
+++ b/Source/tusdotnet/Stores/TusDiskStore.cs
@@ -109,6 +109,8 @@ namespace tusdotnet.Stores
                     bytesWritten += bytesRead;
 
                 } while (bytesRead != 0);
+                
+                file.Write(chunkBuffer.ToArray(), 0, (int)bytesWritten);
 
                 // Chunk is complete. Mark it as complete.
                 chunkComplete.Write("1");


### PR DESCRIPTION
When uploading lagre files AppendDataAsync cause alot of Disk IO and CPU usage ( As single chunk can generate over 1k IO).

Test was done with chunk sizes of 10mb.
Added MemorySteam buffer so we do one disk write when the chunk is complete.