### PR TITLE
Bugfix: Url comparison should not be case sensitive

### DIFF
--- a/Source/tusdotnet/IntentAnalyzer.cs
+++ b/Source/tusdotnet/IntentAnalyzer.cs
@@ -125,7 +125,7 @@ namespace tusdotnet
 
         private static bool UrlMatchesUrlPath(Uri requestUri, string configUrlPath)
         {
-            return requestUri.LocalPath.TrimEnd('/') == configUrlPath.TrimEnd('/');
+            return requestUri.LocalPath.TrimEnd('/').Equals(configUrlPath.TrimEnd('/'), StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool UrlMatchesFileIdUrl(Uri requestUri, string configUrlPath)

--- a/Source/tusdotnet/Models/Concatenation/UploadConcat.cs
+++ b/Source/tusdotnet/Models/Concatenation/UploadConcat.cs
@@ -103,7 +103,7 @@ namespace tusdotnet.Models.Concatenation
 					? uri.LocalPath
 					: uri.ToString();
 
-				if (!localPath.StartsWith(urlPath))
+				if (!localPath.StartsWith(urlPath, StringComparison.OrdinalIgnoreCase))
 				{
 					IsValid = false;
 					ErrorMessage = "Unable to parse Upload-Concat header";


### PR DESCRIPTION
Hi,
i've corrected some inconsistencies in Url comparison's rules (sometimes url comparison was case sensitive, sometimes it wasn't). 
I believe Url comparison shouldn't be case sensitive so i made two small changes to IntentAnalyzer.cs and UploadConcat.cs in order to make comparisons always case insensitive.