### PR TITLE
Use the request path base when creating location header urls

### DIFF
--- a/Source/tusdotnet.test/Tests/ChecksumTests.cs
+++ b/Source/tusdotnet.test/Tests/ChecksumTests.cs
@@ -94,7 +94,7 @@ namespace tusdotnet.test.Tests
             checksumStore.GetSupportedAlgorithmsAsync(CancellationToken.None).ReturnsForAnyArgs(new[] { "sha1" });
             checksumStore.VerifyChecksumAsync(null, null, null, CancellationToken.None).ReturnsForAnyArgs(false);
 
-            var context = new ContextAdapter("/files", MiddlewareUrlHelper.Instance)
+            var context = new ContextAdapter("/files", null, MiddlewareUrlHelper.Instance)
             {
                 CancellationToken = cts.Token,
                 Configuration = new DefaultTusConfiguration

--- a/Source/tusdotnet.test/Tests/ChecksumTrailerTests.cs
+++ b/Source/tusdotnet.test/Tests/ChecksumTrailerTests.cs
@@ -184,7 +184,7 @@ namespace tusdotnet.test.Tests
             httpContext.Features.Set(trailersFeature);
             httpContext.Request.Headers.Add("Trailer", Constants.HeaderConstants.UploadChecksum);
 
-            var context = new ContextAdapter("/files", MiddlewareUrlHelper.Instance)
+            var context = new ContextAdapter("/files", null, MiddlewareUrlHelper.Instance)
             {
                 CancellationToken = cts.Token,
                 Configuration = new DefaultTusConfiguration

--- a/Source/tusdotnet.test/Tests/ModelTests/ValidationContextTests.cs
+++ b/Source/tusdotnet.test/Tests/ModelTests/ValidationContextTests.cs
@@ -82,7 +82,7 @@ namespace tusdotnet.test.Tests.ModelTests
 
         private static ContextAdapter GetContext()
         {
-            return new ContextAdapter("/files", MiddlewareUrlHelper.Instance)
+            return new ContextAdapter("/files", null, MiddlewareUrlHelper.Instance)
             {
                 CancellationToken = CancellationToken.None,
                 Configuration = new DefaultTusConfiguration

--- a/Source/tusdotnet.test/Tests/WriteFilePipelinesTests.cs
+++ b/Source/tusdotnet.test/Tests/WriteFilePipelinesTests.cs
@@ -243,7 +243,7 @@ namespace tusdotnet.test.Tests
                     return -1L; // Won't reach here so just return something.
                 });
 
-            var context = new ContextAdapter("/files", MiddlewareUrlHelper.Instance)
+            var context = new ContextAdapter("/files", null, MiddlewareUrlHelper.Instance)
             {
                 CancellationToken = cts.Token,
                 Configuration = new DefaultTusConfiguration

--- a/Source/tusdotnet.test/Tests/WriteFileStreamsTests.cs
+++ b/Source/tusdotnet.test/Tests/WriteFileStreamsTests.cs
@@ -240,7 +240,7 @@ namespace tusdotnet.test.Tests
             store.AppendDataAsync("testfile", Arg.Any<Stream>(), Arg.Any<CancellationToken>())
                 .ReturnsForAnyArgs<Task<long>>(async callInfo => await callInfo.Arg<Stream>().ReadAsync(null, 0, 0, callInfo.Arg<CancellationToken>()));
 
-            var context = new ContextAdapter("/files", MiddlewareUrlHelper.Instance)
+            var context = new ContextAdapter("/files", null, MiddlewareUrlHelper.Instance)
             {
                 CancellationToken = cts.Token,
                 Configuration = new DefaultTusConfiguration

--- a/Source/tusdotnet/Adapters/ContextAdapter.cs
+++ b/Source/tusdotnet/Adapters/ContextAdapter.cs
@@ -65,12 +65,14 @@ namespace tusdotnet.Adapters
         /// </summary>
         public string ConfigUrlPath => _configUrlPath;
         private readonly string _configUrlPath;
+        private readonly string _requestPathBase;
 
         public IUrlHelper UrlHelper { get; }
 
-        public ContextAdapter(string configUrlPath, IUrlHelper urlHelper)
+        public ContextAdapter(string configUrlPath, string requestPathBase, IUrlHelper urlHelper)
         {
             _configUrlPath = configUrlPath;
+            _requestPathBase = requestPathBase;
             UrlHelper = urlHelper;
 
             Cache = new();
@@ -78,7 +80,9 @@ namespace tusdotnet.Adapters
 
         public string CreateFileLocation(string fileId)
         {
-            return $"{_configUrlPath.TrimEnd('/')}/{fileId}";
+            if (string.IsNullOrWhiteSpace(_requestPathBase))
+                return $"{_configUrlPath.TrimEnd('/')}/{fileId}";
+            return $"{_requestPathBase.TrimEnd('/')}/{_configUrlPath.TrimEnd('/')}/{fileId}";
         }
     }
 }

--- a/Source/tusdotnet/Adapters/ContextAdapter.cs
+++ b/Source/tusdotnet/Adapters/ContextAdapter.cs
@@ -80,10 +80,15 @@ namespace tusdotnet.Adapters
 
         public string CreateFileLocation(string fileId)
         {
-            if (string.IsNullOrWhiteSpace(_requestPathBase))
-                return $"{_configUrlPath.TrimEnd('/')}/{fileId}";
+            return $"{ResolveEndpointUrlWithoutTrailingSlash()}/{fileId}";
+        }
 
-            return $"{_requestPathBase.TrimEnd('/')}/{_configUrlPath.Trim('/')}/{fileId}";
+        public string ResolveEndpointUrlWithoutTrailingSlash()
+        {
+            if (string.IsNullOrWhiteSpace(_requestPathBase))
+                return $"{_configUrlPath.TrimEnd('/')}";
+
+            return $"{_requestPathBase.TrimEnd('/')}/{_configUrlPath.Trim('/')}";
         }
     }
 }

--- a/Source/tusdotnet/Adapters/ContextAdapter.cs
+++ b/Source/tusdotnet/Adapters/ContextAdapter.cs
@@ -82,7 +82,8 @@ namespace tusdotnet.Adapters
         {
             if (string.IsNullOrWhiteSpace(_requestPathBase))
                 return $"{_configUrlPath.TrimEnd('/')}/{fileId}";
-            return $"{_requestPathBase.TrimEnd('/')}/{_configUrlPath.TrimEnd('/')}/{fileId}";
+
+            return $"{_requestPathBase.TrimEnd('/')}/{_configUrlPath.Trim('/')}/{fileId}";
         }
     }
 }

--- a/Source/tusdotnet/ExternalMiddleware/Core/TusCoreMiddleware.cs
+++ b/Source/tusdotnet/ExternalMiddleware/Core/TusCoreMiddleware.cs
@@ -53,7 +53,7 @@ namespace tusdotnet
 
             var request = DotnetCoreAdapterFactory.CreateRequestAdapter(httpContext, requestUri);
 
-            var contextAdapter = new ContextAdapter(config.UrlPath, MiddlewareUrlHelper.Instance)
+            var contextAdapter = new ContextAdapter(config.UrlPath, null, MiddlewareUrlHelper.Instance)
             {
                 Request = request,
                 Configuration = config,

--- a/Source/tusdotnet/ExternalMiddleware/Core/TusEndpointInvoker.cs
+++ b/Source/tusdotnet/ExternalMiddleware/Core/TusEndpointInvoker.cs
@@ -32,8 +32,9 @@ namespace tusdotnet
 
             var urlPath = GetUrlPath(context);
             var request = CreateRequestAdapter(context);
+            var pathBase = context.Request.PathBase.HasValue ? context.Request.PathBase.Value : null;
 
-            var contextAdapter = new ContextAdapter(urlPath, EndpointUrlHelper.Instance)
+            var contextAdapter = new ContextAdapter(urlPath, pathBase, EndpointUrlHelper.Instance)
             {
                 Request = request,
                 Configuration = config,

--- a/Source/tusdotnet/ExternalMiddleware/Owin/TusOwinMiddleware.cs
+++ b/Source/tusdotnet/ExternalMiddleware/Owin/TusOwinMiddleware.cs
@@ -58,7 +58,7 @@ namespace tusdotnet
                 RequestUri = context.Request.Uri
             };
 
-            var contextAdapter = new ContextAdapter(config.UrlPath, MiddlewareUrlHelper.Instance)
+            var contextAdapter = new ContextAdapter(config.UrlPath, null, MiddlewareUrlHelper.Instance)
             {
                 Request = request,
                 Configuration = config,

--- a/Source/tusdotnet/IntentHandlers/ConcatenateFilesHandler.cs
+++ b/Source/tusdotnet/IntentHandlers/ConcatenateFilesHandler.cs
@@ -93,7 +93,7 @@ namespace tusdotnet.IntentHandlers
 
         private UploadConcat ParseUploadConcatHeader()
         {
-            return new UploadConcat(Request.Headers.UploadConcat, Context.ConfigUrlPath);
+            return new UploadConcat(Request.Headers.UploadConcat, Context.ResolveEndpointUrlWithoutTrailingSlash());
         }
 
         private async Task<string> HandleCreationOfConcatFiles(long uploadLength, string metadataString)

--- a/Source/tusdotnet/IntentHandlers/CreateFileHandler.cs
+++ b/Source/tusdotnet/IntentHandlers/CreateFileHandler.cs
@@ -56,7 +56,7 @@ namespace tusdotnet.IntentHandlers
             var metadata = Request.Headers.UploadMetadata;
             var fileId = await Context.StoreAdapter.CreateFileAsync(Request.Headers.UploadLength, metadata, CancellationToken);
 
-            
+
             DateTimeOffset? expires = null;
             long? uploadOffset = null;
 
@@ -72,12 +72,12 @@ namespace tusdotnet.IntentHandlers
 
             Context.FileId = fileId;
 
-            SetReponseHeaders(fileId, expires, uploadOffset);
+            SetResponseHeaders(fileId, expires, uploadOffset);
 
             Response.SetResponse(HttpStatusCode.Created);
         }
 
-        private void SetReponseHeaders(string fileId, DateTimeOffset? expires, long? uploadOffset)
+        private void SetResponseHeaders(string fileId, DateTimeOffset? expires, long? uploadOffset)
         {
             if (expires != null)
             {

--- a/Source/tusdotnet/IntentHandlers/GetFileInfoHandler.cs
+++ b/Source/tusdotnet/IntentHandlers/GetFileInfoHandler.cs
@@ -79,7 +79,7 @@ namespace tusdotnet.IntentHandlers
 
             if (uploadConcat != null)
             {
-                (uploadConcat as FileConcatFinal)?.AddUrlPathToFiles(Context.ConfigUrlPath);
+                (uploadConcat as FileConcatFinal)?.AddUrlPathToFiles(Context.ResolveEndpointUrlWithoutTrailingSlash());
                 Response.SetHeader(HeaderConstants.UploadConcat, uploadConcat.GetHeader());
             }
 

--- a/Source/tusdotnet/Runners/TusV1EventRunner.cs
+++ b/Source/tusdotnet/Runners/TusV1EventRunner.cs
@@ -38,9 +38,9 @@ namespace tusdotnet
 
         private static async Task<ResultType> RunWithEvents(this IntentHandlerWithEvents handler, ContextAdapter context, bool swallowExceptionsDuringInvoke)
         {
-            var onAuhorizeResult = await handler.Authorize();
+            var onAuthorizeResult = await handler.Authorize();
 
-            if (onAuhorizeResult == ResultType.StopExecution)
+            if (onAuthorizeResult == ResultType.StopExecution)
             {
                 return ResultType.StopExecution;
             }

--- a/Source/tusdotnet/Validation/Requirements/UploadConcatForConcatenateFiles.cs
+++ b/Source/tusdotnet/Validation/Requirements/UploadConcatForConcatenateFiles.cs
@@ -44,7 +44,7 @@ namespace tusdotnet.Validation.Requirements
             var filesArePartial = await Task.WhenAll(
                 finalConcat.Files.Select(f => context.StoreAdapter.GetUploadConcatAsync(f, context.CancellationToken)));
 
-            if (filesArePartial.Any(f => !(f is FileConcatPartial)))
+            if (filesArePartial.Any(f => f is not FileConcatPartial))
             {
                 await BadRequest($"Some of the files supplied for concatenation are not marked as partial and can not be concatenated: {string.Join(", ", filesArePartial.Zip(finalConcat.Files, (s, s1) => new { partial = s is FileConcatPartial, name = s1 }).Where(f => !f.partial).Select(f => f.name))}");
                 return;


### PR DESCRIPTION
Use the request path base when creating url for the upload location header. The base base is only used for the endpoint based invoker, as this is backwards compatible with the previouse behaviour.

The middleware approach always defined the absolut url which is used, and if there are existing configurations which include the path base this will break the backwards compat.