### PR TITLE
Add OnBeforeWrite Event

### DIFF
--- a/Source/tusdotnet.test/Tests/WriteFileStreamsTests.cs
+++ b/Source/tusdotnet.test/Tests/WriteFileStreamsTests.cs
@@ -611,6 +611,70 @@ namespace tusdotnet.test.Tests
             onUploadCompleteCallCounts.ShouldBe(0);
             onFileCompleteAsyncCallbackCounts.ShouldBe(0);
         }
+        
+        [Fact]
+        public async Task OnBeforeWrite_Is_Called()
+        {
+            var onBeforeWriteWasCalled = false;
+            var store = Substitute
+                .For<ITusStore>()
+                .WithExistingFile("testfile", uploadLength: 10, uploadOffset: 5);
+            store
+                .AppendDataAsync("testfile", Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+                .Returns(5);
+
+            using var server = TestServerFactory.Create(
+                store,
+                new Events
+                {
+                    OnBeforeWriteAsync = _ =>
+                    {
+                        onBeforeWriteWasCalled = true;
+                        return Task.FromResult(0);
+                    },
+                }
+            );
+            var response = await server
+                .CreateTusResumableRequest("/files/testfile")
+                .AddHeader("Upload-Offset", "5")
+                .AddBody()
+                .SendAsync("PATCH");
+
+            response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+            onBeforeWriteWasCalled.ShouldBeTrue();
+        }
+        
+        [Fact]
+        public async Task Request_Is_Cancelled_If_OnBeforeWrite_Fails_The_Request()
+        {
+            var store = Substitute
+                .For<ITusStore>()
+                .WithExistingFile("testfile", uploadLength: 10, uploadOffset: 5);
+            store
+                .AppendDataAsync("testfile", Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+                .Returns(5);
+
+            using var server = TestServerFactory.Create(
+                store,
+                new Events
+                {
+                    OnBeforeWriteAsync = ctx =>
+                    {
+                        ctx.FailRequest(HttpStatusCode.BadRequest);
+                        return Task.FromResult(0);
+                    },
+                }
+            );
+            var response = await server
+                .CreateTusResumableRequest("/files/testfile")
+                .AddHeader("Upload-Offset", "5")
+                .AddBody()
+                .SendAsync("PATCH");
+            
+            response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+            response.ShouldNotContainHeaders("Upload-Offset");
+        }
 
         [Fact]
         public async Task OnAuthorized_Is_Called()

--- a/Source/tusdotnet/Helpers/Internal/EventHelper.cs
+++ b/Source/tusdotnet/Helpers/Internal/EventHelper.cs
@@ -76,6 +76,9 @@ namespace tusdotnet.Helpers
 
             if (t == typeof(CreateCompleteContext))
                 return (Func<T, Task>)events.OnCreateCompleteAsync;
+            
+            if (t == typeof(BeforeWriteContext))
+                return (Func<T, Task>)events.OnBeforeWriteAsync;
 
             if (t == typeof(BeforeDeleteContext))
                 return (Func<T, Task>)events.OnBeforeDeleteAsync;

--- a/Source/tusdotnet/Models/Configuration/BeforeWriteContext.cs
+++ b/Source/tusdotnet/Models/Configuration/BeforeWriteContext.cs
@@ -1,0 +1,17 @@
+﻿namespace tusdotnet.Models.Configuration;
+
+/// <summary>
+/// Context for the OnBeforeWrite event
+/// </summary>
+public class BeforeWriteContext : ValidationContext<BeforeWriteContext>
+{
+    /// <summary>
+    /// The length (in bytes) of the file being created.
+    /// </summary>
+    public long UploadLength { get; set; }
+    
+    /// <summary>
+    /// The length (in bytes) of the currently uploaded file size.
+    /// </summary>
+    public long UploadOffset { get; set; }
+}

--- a/Source/tusdotnet/Models/Configuration/Events.cs
+++ b/Source/tusdotnet/Models/Configuration/Events.cs
@@ -9,6 +9,13 @@ namespace tusdotnet.Models.Configuration
     public class Events
     {
         /// <summary>
+        /// Callback ran right before a file upload starts. This callback can be used to validate
+        /// the request before starting the upload. Calling the <see cref="ValidationContext{TSelf}.FailRequest(string)" /> method on the context
+        /// will return a 400 Bad Request to the client.
+        /// </summary>
+        public Func<BeforeWriteContext, Task> OnBeforeWriteAsync { get; set; }
+
+        /// <summary>
         /// Callback ran when a file is completely uploaded.
         /// This callback is called only once after the last bytes have been written to the store or
         /// after a "final" file has been created using the concatenation extension.

--- a/Source/tusdotnet/Runners/Events/WriteFileHandlerWithEvents.cs
+++ b/Source/tusdotnet/Runners/Events/WriteFileHandlerWithEvents.cs
@@ -54,9 +54,16 @@ namespace tusdotnet.Runners.Events
             await EventHelper.NotifyFileComplete(Context);
         }
 
-        internal override Task<ResultType> ValidateBeforeAction()
+        internal override async Task<ResultType> ValidateBeforeAction()
         {
-            return Task.FromResult(ResultType.ContinueExecution);
+            return await EventHelper.Validate<BeforeWriteContext>(
+                Context,
+                ctx =>
+                {
+                    ctx.UploadLength = Context.Request.Headers.UploadLength;
+                    ctx.UploadOffset = Context.Request.Headers.UploadOffset;
+                }
+            );
         }
     }
 }


### PR DESCRIPTION
Added an OnBeforeWrite Event.

This event is called on each PATCH request being sent and can be used to verify the incoming request.